### PR TITLE
frida.attach does not work for Linux->iOS

### DIFF
--- a/xpcspy/utils/agent.py
+++ b/xpcspy/utils/agent.py
@@ -24,7 +24,7 @@ class Agent:
         with open(self._script_path) as src_f:
             self._script_src = src_f.read()
         try:
-            session = frida.attach(target)  # `target` is str or int depending on whether it's a name or pid
+            session = self.device.attach(target)  # `target` is str or int depending on whether it's a name or pid
         except frida.PermissionDeniedError:
             logger.exit_with_error(f"You don't have enough permissions to attach to {target}, try sudo?")
         click.secho(f"[!] Successfully attached to {target}", fg='green')


### PR DESCRIPTION
...got `xpcspy` working on iOS 14.2 on an iPhone 8 with a Linux host but I had to change this line :) Awesome project!

I also noticed that Jetsam might kill processes with too many XPC messages when attaching to them, at least without filter. I already increased the Jetsam limits for the target process. In my experience, processing as few data as possible with JavaScript/Frida can solve such issues.