### PR TITLE
Added basic bplist17 support (Tested on iOS 14.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _agent.js
 */node_modules
 xpcspy.egg-info/
 dist/
+venv/

--- a/agent/src/hooking.ts
+++ b/agent/src/hooking.ts
@@ -75,9 +75,24 @@ const _onEnterHandler = function(symbol: string,
 	if (shouldParse) {
 		const messageType = objcObjectDebugDesc(<NativePointer>xpcGetType.call(p_message));
 		if (messageType == 'OS_xpc_dictionary') {
-			const parsingResult = parseBPListKeysRecursively(p_message);
-			if (parsingResult.length > 0) {
-				messageDesc = formatMessageDescription(messageDesc, parsingResult);
+
+			if(messageDesc.includes('"root"')) {
+				let decoder = ObjC.classes.NSXPCDecoder.alloc().init();
+				decoder["- set_connection:"](p_connection);
+
+				decoder["- _startReadingFromXPCObject:"](p_message);
+				
+				messageDesc = formatMessageDescription(messageDesc, [{
+					format: "bplist17",
+					data: decoder.debugDescription(),
+					key: "root"
+				}]);
+				decoder.dealloc();
+			} else {
+				const parsingResult = parseBPListKeysRecursively(p_message);
+				if (parsingResult.length > 0) {
+					messageDesc = formatMessageDescription(messageDesc, parsingResult);
+				}
 			}
 		} // Parse `OS_xpc_data` as well?
 	}

--- a/agent/src/lib/helpers.ts
+++ b/agent/src/lib/helpers.ts
@@ -109,5 +109,5 @@ function hexStringForBytes(bytesPtr: NativePointer, length: Object) {
 
 export function isSupportedBPListData(bytesPtr: NativePointer): boolean {
     const magic = bytesPtr.readCString(8);
-    return magic == 'bplist00' || magic == 'bplist15'; 
+    return magic == 'bplist00' || magic == 'bplist15' || magic == 'bplist17'; 
 }

--- a/agent/src/lib/helpers.ts
+++ b/agent/src/lib/helpers.ts
@@ -104,10 +104,3 @@ function hexStringForBytes(bytesPtr: NativePointer, length: Object) {
 
     return hexString; 
 }
-
-
-
-export function isSupportedBPListData(bytesPtr: NativePointer): boolean {
-    const magic = bytesPtr.readCString(8);
-    return magic == 'bplist00' || magic == 'bplist15' || magic == 'bplist17'; 
-}

--- a/agent/src/lib/interfaces.ts
+++ b/agent/src/lib/interfaces.ts
@@ -7,7 +7,7 @@ export interface IFilter {
 
 export interface IParsingResult {
     key: string | null,
-    format: 'bplist00' | 'bplist15' | 'bplist16',
+    format: 'bplist00' | 'bplist15' | 'bplist16' | 'bplist17',
     data: string
 }
 

--- a/agent/src/lib/interfaces.ts
+++ b/agent/src/lib/interfaces.ts
@@ -5,9 +5,15 @@ export interface IFilter {
     connectionNamePattern: string
 }
 
+export type SupportedBPListFormat =
+    "bplist00" |
+    "bplist15" |
+    "bplist16" |
+    "bplist17";
+
 export interface IParsingResult {
     key: string | null,
-    format: 'bplist00' | 'bplist15' | 'bplist16' | 'bplist17',
+    format: SupportedBPListFormat,
     data: string
 }
 


### PR DESCRIPTION
I added bplist17 (and 16 as well) parsing support:

I used the XPCDecoder class to load the xpc message and decoding it, so it should support all the formats (not tested yet).
Currently, I'm just printing the debugDescription which giving a nice picture of what going on, but we can also run over the loaded classes and try to print their description using toString method. 

I tested this on iOS 14.6, you're welcome to test on other iOS versions. 