### PR TITLE
Resume execution of swapned applications

### DIFF
--- a/xpcspy/utils/agent.py
+++ b/xpcspy/utils/agent.py
@@ -40,6 +40,7 @@ class Agent:
 
         if mtype == 'agent:hooks_installed':
             ui._update_status("Hooks installed, intercepting messages...")
+            ui._resume()
         elif mtype == 'agent:trace:symbol':
             symbol = message['payload']['message']['symbol']
             timestamp = message['payload']['message']['timestamp']


### PR DESCRIPTION
When the target isn't running yet, frida will spawn it in a suspended state.
When using the `frida` command, the `--no-pause` option will resume the application after loading the agent script.
To resemble the same semantic I added a call to `ConsoleApplication#_resume()` after the agent has notified the successful loading.
This shall not affect other scenarios as resuming an already running target shall do nothing, but I haven't tried that yet.

How to reproduce:
```
ssh -q root@iPhone killall Calculator
time xpcspy -U -f com.apple.calculator # this will terminate after 20 seconds, as the watchdog is killing apps that stay idle for that long unless are being debugged
```

Thank you very much for this great tool! Is of great inspiration and very useful for playing around with iOS :)
I hope this helps!